### PR TITLE
Push to ADS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "ads-schemas"]
-	path = train-simulation/edge/src/edgefarm/ads-schemas
-	url = git@github.com:edgefarm/ads-schemas.git
-	branch = initial

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ads-schemas"]
+	path = train-simulation/edge/src/edgefarm/ads-schemas
+	url = git@github.com:edgefarm/ads-schemas.git
+	branch = initial

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,5 +23,5 @@ repos:
     rev: 3.9.1
     hooks:
       - id: flake8
-        args: [--max-line-length=130]
+        args: [--max-line-length=180]
         additional_dependencies: ["pycodestyle==2.7.0"]

--- a/train-simulation/edge/.gitignore
+++ b/train-simulation/edge/.gitignore
@@ -1,3 +1,4 @@
 .dobi
 .vscode
 gen
+manifest.work.yaml

--- a/train-simulation/edge/manifest.yaml
+++ b/train-simulation/edge/manifest.yaml
@@ -8,9 +8,16 @@ modules:
     status: running
     startupOrder: 1
     envs:
-      MQTT_SERVER: 192.168.24.14:1883
+      MQTT_SERVER: <IP>:1883
   - name: edge-demo
-    image:  harbor.ci4rail.com/edgefarm/train-simulator-edge-demo:0.1.0-11.Branch.main.Sha.80849351b5dedfb10f4c894c2cf4e471d16e0708
+    image:  harbor.ci4rail.com/edgefarm-dev/train-simulator-edge-demo:05b50cd
+    createOptions: '{}'
+    imagePullPolicy: on-create
+    restartPolicy: always
+    status: running
+    startupOrder: 1
+  - name: ads-node-module
+    image: harbor.ci4rail.com/edgefarm/ads-node-module:0.1.0-9.Branch.main.Sha.0e4f2e736b64fc1c69b5479743ee89580bdcf3fe
     createOptions: '{}'
     imagePullPolicy: on-create
     restartPolicy: always

--- a/train-simulation/edge/manifest.yaml
+++ b/train-simulation/edge/manifest.yaml
@@ -8,7 +8,7 @@ modules:
     status: running
     startupOrder: 1
     envs:
-      MQTT_SERVER: <IP>:1883
+      MQTT_SERVER: 192.168.24.14:1883
   - name: edge-demo
     image:  harbor.ci4rail.com/edgefarm/train-simulator-edge-demo:0.1.0-11.Branch.main.Sha.80849351b5dedfb10f4c894c2cf4e471d16e0708
     createOptions: '{}'

--- a/train-simulation/edge/pipeline-pullrequests.yaml
+++ b/train-simulation/edge/pipeline-pullrequests.yaml
@@ -20,7 +20,7 @@ resources:
       repository: edgefarm/edgefarm-demos
       access_token: ((access_token))
       paths:
-        - train-simulation/edge/*
+        - train-simulation/edge/**/*
 
   - name: image-train-simulator-edge-demo-dev
     type: docker-buildx

--- a/train-simulation/edge/src/Makefile
+++ b/train-simulation/edge/src/Makefile
@@ -6,6 +6,12 @@ install_dependencies:
 	curl -O https://raw.githubusercontent.com/edgefarm/alm-service-modules/main/alm-mqtt-module/pkg/schema/avro_schemas/unregisterSubResponse.avro && \
 	curl -O https://raw.githubusercontent.com/edgefarm/alm-service-modules/main/alm-mqtt-module/pkg/client/avro_schemas/dataSchema.avro
 
+	mkdir -p edgefarm/ads_schemas && cd edgefarm/ads_schemas && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/ads_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/temperature_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/gps_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/mvb_data.avsc
+
 install_requirements:
 	pip3 install -r requirements.txt
 

--- a/train-simulation/edge/src/Makefile
+++ b/train-simulation/edge/src/Makefile
@@ -7,10 +7,10 @@ install_dependencies:
 	curl -O https://raw.githubusercontent.com/edgefarm/alm-service-modules/main/alm-mqtt-module/pkg/client/avro_schemas/dataSchema.avro
 
 	mkdir -p edgefarm/ads_schemas && cd edgefarm/ads_schemas && \
-	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/ads_data.avsc && \
-	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/temperature_data.avsc && \
-	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/gps_data.avsc && \
-	curl -O https://raw.githubusercontent.com/edgefarm/ads-schemas/main/mvb_data.avsc
+	curl -O https://raw.githubusercontent.com/edgefarm/ads_schemas/main/ads_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads_schemas/main/temperature_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads_schemas/main/gps_data.avsc && \
+	curl -O https://raw.githubusercontent.com/edgefarm/ads_schemas/main/mvb_data.avsc
 
 install_requirements:
 	pip3 install -r requirements.txt

--- a/train-simulation/edge/src/edgefarm/ads.py
+++ b/train-simulation/edge/src/edgefarm/ads.py
@@ -29,6 +29,14 @@ class AdsProducer:
     async def publish(self, data):
         await self.nc.publish("ads", data)
 
+    async def close(self):
+        if self.nc.is_closed:
+            return
+        try:
+            await self.nc.close()
+        except Exception as e:
+            print(e)
+
 
 class AdsEncoder:
     def __init__(self, app, module, payload_schemas):

--- a/train-simulation/edge/src/edgefarm/ads.py
+++ b/train-simulation/edge/src/edgefarm/ads.py
@@ -1,0 +1,75 @@
+import os
+from nats.aio.client import Client as Nats
+import fastavro
+from .avro import schemaless_encode
+
+
+class AdsProducer:
+    def __init__(self, loop):
+        self.nc = Nats()
+        self.loop = loop
+        self.serverRunning = False
+
+    async def connect(self):
+        """Connect to the nats server.
+        You can specify the nats server by defining the environment
+        variable `NATS_SERVER`, e.g. `nats:4222`.
+        """
+        nats_server = os.getenv("NATS_SERVER", "nats:4222")
+        options = {
+            "servers": ["nats://" + nats_server],
+            "loop": self.loop,
+            "connect_timeout": 10,
+            "ping_interval": 1,
+            "max_outstanding_pings": 5,
+        }
+
+        await self.nc.connect(**options)
+
+    async def publish(self, data):
+        await self.nc.publish("ads", data)
+
+
+class AdsEncoder:
+    def __init__(self, app, module, payload_schemas):
+        self.codec = fastavro.schema.load_schema("edgefarm/ads-schemas/ads_data.avsc")
+        self.payload_codecs = {}
+        self.app = app
+        self.module = module
+        self.sequence_number = 0
+        for f in payload_schemas:
+            self.payload_codecs[f] = fastavro.schema.load_schema(
+                f"edgefarm/ads-schemas/{f}.avsc"
+            )
+
+    def encode(self, tags, payload_schema, schema_version, data):
+        """
+        Generate an ADS_DATA avro (schemaless) message with an embedded avro payload of using the <payload_schema>.
+        <payload_schema> must have been specified when initializing this component
+        """
+
+        if payload_schema not in self.payload_codecs.keys():
+            raise ValueError(f"schema {payload_schema} unknown")
+
+        # encode payload
+        payload = schemaless_encode(data, self.payload_codecs[payload_schema])
+
+        # encode ADS_DATA
+        msg = {
+            "meta": {"version": b"\x01\x00\x00"},
+            "origin": {
+                "app": self.app,
+                "module": self.module,
+                "tags": tags,
+                "sequenceNumber": self.sequence_number,
+            },
+            "payload": {
+                "format": "avro",
+                "schema": payload_schema + ".avsc",
+                "schemaVersion": schema_version,
+                "data": payload,
+            },
+        }
+        avro_msg = schemaless_encode(msg, self.codec)
+        self.sequence_number += 1
+        return avro_msg

--- a/train-simulation/edge/src/edgefarm/ads.py
+++ b/train-simulation/edge/src/edgefarm/ads.py
@@ -40,14 +40,14 @@ class AdsProducer:
 
 class AdsEncoder:
     def __init__(self, app, module, payload_schemas):
-        self.codec = fastavro.schema.load_schema("edgefarm/ads-schemas/ads_data.avsc")
+        self.codec = fastavro.schema.load_schema("edgefarm/ads_schemas/ads_data.avsc")
         self.payload_codecs = {}
         self.app = app
         self.module = module
         self.sequence_number = 0
         for f in payload_schemas:
             self.payload_codecs[f] = fastavro.schema.load_schema(
-                f"edgefarm/ads-schemas/{f}.avsc"
+                f"edgefarm/ads_schemas/{f}.avsc"
             )
 
     def encode(self, tags, payload_schema, schema_version, data):

--- a/train-simulation/edge/src/edgefarm/ads_schemas/ads_data.avsc
+++ b/train-simulation/edge/src/edgefarm/ads_schemas/ads_data.avsc
@@ -1,0 +1,57 @@
+{
+    "name": "adsData",
+    "type":	"record",
+    "fields": [
+        {
+            "name": "meta",
+            "type": {
+                "name": "t_meta",
+                "type": "record",
+                "fields": [
+                    { "name": "format", "type": "string", "default": "ADS_DATA" },
+                    { "name": "version", "type": "bytes" }
+                ]
+            }
+        },
+        {
+            "name": "origin",
+            "type": {
+                "name": "t_origin",
+                "type": "record",
+                "fields": [
+                    { "name": "app", "type": "string" },
+                    { "name": "module", "type": "string" },
+                    {
+                        "name": "tags",
+                        "type": {
+                            "name": "t_tags",
+                            "type": "array",
+                            "items": {
+                                "name": "tag",
+                                "type": "record",
+                                "fields" : [
+                                    { "name": "key", "type": "string"},
+                                    { "name": "value", "type": "string"}
+                                ]
+                            }
+                        }
+                    },
+                    { "name": "sequenceNumber", "type": "int" }
+                ]
+            }
+        },
+        {
+            "name": "payload",
+            "type": {
+                "name": "t_payload",
+                "type": "record",
+                "fields": [
+                    { "name": "format", "type": "string" },
+                    { "name": "schema", "type": "string" },
+                    { "name": "schemaVersion", "type": "bytes" },
+                    { "name": "data", "type": "bytes" }
+                ]
+            }
+        }
+    ]
+}

--- a/train-simulation/edge/src/edgefarm/ads_schemas/gps_data.avsc
+++ b/train-simulation/edge/src/edgefarm/ads_schemas/gps_data.avsc
@@ -1,0 +1,37 @@
+{
+    "name": "gpsData",
+    "type":	"record",
+    "fields": [
+        {
+            "name": "meta",
+            "type": {
+                "name": "t_meta",
+                "type": "record",
+                "fields": [
+                    { "name": "version", "type": "bytes" }
+                ]
+            }
+        },
+        {
+            "name": "data",
+            "type": {
+                "name": "t_data",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "time",
+                        "type": {
+                            "doc": "acquisition time in microseconds since 1.1.1970",
+                            "type": "long",
+                            "logicalType": "timestamp-micros"
+                        }
+                    },
+                    { "name": "lat", "type": "double" },
+                    { "name": "lon", "type": "double" },
+                    { "name": "alt", "type": "double" },
+                    { "name": "gpsMode", "type": "int" }
+                ]
+            }
+        }
+    ]
+}

--- a/train-simulation/edge/src/edgefarm/ads_schemas/mvb_data.avsc
+++ b/train-simulation/edge/src/edgefarm/ads_schemas/mvb_data.avsc
@@ -1,0 +1,42 @@
+{
+    "name": "mvbData",
+    "type":	"record",
+    "fields": [
+        {
+            "name": "meta",
+            "type": {
+                "name": "t_meta",
+                "type": "record",
+                "fields": [
+                    { "name": "version", "type": "bytes" }
+                ]
+            }
+        },
+        {
+            "name": "dataRows",
+            "type": {
+                "name": "t_dataRows",
+                "type": "array",
+                "items": {
+                    "name": "row",
+                    "type": {
+                        "name": "t_row",
+                        "type": "record",
+                        "fields" : [
+                            {
+                                "name": "time",
+                                "type": {
+                                    "doc": "acquisition time in microseconds since 1.1.1970",
+                                    "type": "long",
+                                    "logicalType": "timestamp-micros"
+                                }
+                            },
+                            { "name": "port", "type": "int" },
+                            { "name": "messageData", "type": "bytes" }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/train-simulation/edge/src/edgefarm/ads_schemas/temperature_data.avsc
+++ b/train-simulation/edge/src/edgefarm/ads_schemas/temperature_data.avsc
@@ -1,0 +1,35 @@
+{
+    "name": "temperatureData",
+    "type":	"record",
+    "fields": [
+        {
+            "name": "meta",
+            "type": {
+                "name": "t_meta",
+                "type": "record",
+
+                "fields": [
+                    { "name": "version", "type": "bytes" }
+                ]
+            }
+        },
+        {
+            "name": "data",
+            "type": {
+                "name": "t_data",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "time",
+                        "type": {
+                            "doc": "acquisition time in microseconds since 1.1.1970",
+                            "type": "long",
+                            "logicalType": "timestamp-micros"
+                        }
+                    },
+                    { "name": "temp", "type": "double" }
+                ]
+            }
+        }
+    ]
+}

--- a/train-simulation/edge/src/edgefarm/alm_mqtt_module_client.py
+++ b/train-simulation/edge/src/edgefarm/alm_mqtt_module_client.py
@@ -1,6 +1,5 @@
 import os
 from nats.aio.client import Client as Nats
-import asyncio
 import edgefarm.client as client
 
 
@@ -8,6 +7,7 @@ class AlmMqttModuleClient:
     """A class to interact with the `alm-mqtt-module`. It supports
     registering and unregistering to MQTT topics proxied over nats
     via `alm-mqtt-module`."""
+
     __subjects = {}
     __subject_handlers = {}
 
@@ -45,13 +45,13 @@ class AlmMqttModuleClient:
         await mqttClient.connect()
         ```
         """
-        nats_server = os.getenv('NATS_SERVER', 'nats:4222')
+        nats_server = os.getenv("NATS_SERVER", "nats:4222")
         options = {
-            "servers": ["nats://"+nats_server],
+            "servers": ["nats://" + nats_server],
             "loop": self.loop,
             "connect_timeout": 10,
             "ping_interval": 1,
-            "max_outstanding_pings": 5
+            "max_outstanding_pings": 5,
         }
 
         await self.nc.connect(**options)
@@ -84,12 +84,14 @@ class AlmMqttModuleClient:
         """
         response = await client.register_mqtt_topic("alm-mqtt-module", topic, self.nc)
         self.serverRunning = True
-        self.__subjects[response.subject] = await self.nc.subscribe(subject=response.subject, cb=self.__nats_handler)
+        self.__subjects[response.subject] = await self.nc.subscribe(
+            subject=response.subject, cb=self.__nats_handler
+        )
         self.__subject_handlers[response.subject] = handler
         return response.subject
 
     async def __nats_handler(self, msg):
-        await self.nc.publish(msg.reply, b'')
+        await self.nc.publish(msg.reply, b"")
         await self.__subject_handlers[msg.subject](msg)
 
     async def unsubscribe(self, subject):
@@ -128,5 +130,4 @@ class AlmMqttModuleClient:
             await self.nc.close()
         except Exception as e:
             print(e)
-        await asyncio.sleep(0.1)
-        self.loop.stop()
+        # await asyncio.sleep(0.1)

--- a/train-simulation/edge/src/edgefarm/avro.py
+++ b/train-simulation/edge/src/edgefarm/avro.py
@@ -1,16 +1,35 @@
 from io import BytesIO
-from fastavro import writer, reader
+from fastavro import writer, reader, schemaless_writer
 
 
-def new_writer(msg, schema):
+def schema_encode(msg, schema):
+    '''
+    Binary encoding of message. Schema is part of binary.
+    Return binary as bytes.
+    '''
     fo = BytesIO()
     writer(fo=fo, schema=schema, records=msg)
     fo.seek(0)
-    return fo
+    return fo.read()
 
 
-def new_reader(data):
+def schema_decode(data):
+    '''
+    Decoding of an Avro binary that contains the schema.
+    Return the first decoded message
+    '''
     avro_reader = reader(data)
     # Returning all other records. Only returning the first one.
     for record in avro_reader:
         return record
+
+
+def schemaless_encode(msg, schema):
+    '''
+    Binary encoding of message. Schema is NOT part of binary.
+    Return binary as bytes.
+    '''
+    fo = BytesIO()
+    schemaless_writer(fo=fo, schema=schema, record=msg)
+    fo.seek(0)
+    return fo.read()

--- a/train-simulation/edge/src/edgefarm/avro.py
+++ b/train-simulation/edge/src/edgefarm/avro.py
@@ -1,12 +1,12 @@
 from io import BytesIO
-from fastavro import writer, reader, schemaless_writer
+from fastavro import writer, reader, schemaless_writer, schemaless_reader
 
 
 def schema_encode(msg, schema):
-    '''
+    """
     Binary encoding of message. Schema is part of binary.
     Return binary as bytes.
-    '''
+    """
     fo = BytesIO()
     writer(fo=fo, schema=schema, records=msg)
     fo.seek(0)
@@ -14,10 +14,10 @@ def schema_encode(msg, schema):
 
 
 def schema_decode(data):
-    '''
+    """
     Decoding of an Avro binary that contains the schema.
     Return the first decoded message
-    '''
+    """
     avro_reader = reader(data)
     # Returning all other records. Only returning the first one.
     for record in avro_reader:
@@ -25,11 +25,17 @@ def schema_decode(data):
 
 
 def schemaless_encode(msg, schema):
-    '''
+    """
     Binary encoding of message. Schema is NOT part of binary.
     Return binary as bytes.
-    '''
+    """
     fo = BytesIO()
     schemaless_writer(fo=fo, schema=schema, record=msg)
     fo.seek(0)
     return fo.read()
+
+
+def schemaless_decode(data, schema):
+    fo = BytesIO(data)
+    m = schemaless_reader(fo, schema)
+    return m

--- a/train-simulation/edge/src/edgefarm/client.py
+++ b/train-simulation/edge/src/edgefarm/client.py
@@ -13,15 +13,14 @@ async def register_mqtt_topic(target, topic, nats_client):
     msg = [
         {u'topic': topic}
     ]
-    data = avro.new_writer(msg, schema.register_sub_request_codec)
-    data.seek(0)
+    data = avro.schema_encode(msg, schema.register_sub_request_codec)
 
-    resp_msg = await nats_client.request(target+".config.register", data.read(), timeout=2)
-    resp = avro.new_reader(io.BytesIO(resp_msg.data))
+    resp_msg = await nats_client.request(target + ".config.register", data, timeout=2)
+    resp = avro.schema_decode(io.BytesIO(resp_msg.data))
     r = RegisterResponse(subject=resp["subject"], error=resp["error"])
     error = resp["error"]
     if len(error) > 0:
-        print("Error: "+error)
+        print("Error: " + error)
     return r
 
 
@@ -29,13 +28,12 @@ async def unergister_mqtt_topic(target, subject, nats_client):
     msg = [
         {u'subject': subject}
     ]
-    data = avro.new_writer(msg, schema.unregister_sub_request_codec)
-    data.seek(0)
+    data = avro.schema_encode(msg, schema.unregister_sub_request_codec)
     try:
-        resp_msg = await nats_client.request(target+".config.unregister", data.read(), timeout=2)
+        resp_msg = await nats_client.request(target + ".config.unregister", data, timeout=2)
     except Exception as e:
         raise Exception("Error: timeout to alm-mqtt-module {}".format(e))
-    resp = avro.new_reader(io.BytesIO(resp_msg.data))
+    resp = avro.schema_decode(io.BytesIO(resp_msg.data))
     error = resp["error"]
     if len(error) > 0:
-        print("Error: "+error)
+        print("Error: " + error)

--- a/train-simulation/edge/src/edgefarm/schema.py
+++ b/train-simulation/edge/src/edgefarm/schema.py
@@ -11,3 +11,5 @@ unregister_sub_response_codec = fastavro.schema.load_schema(
     "edgefarm/avro_schemas/unregisterSubResponse.avro")
 data_codec = fastavro.schema.load_schema(
     "edgefarm/avro_schemas/dataSchema.avro")
+ads_codec = fastavro.schema.load_schema(
+    "edgefarm/ads-schemas/ads_data.avsc")

--- a/train-simulation/edge/src/edgefarm/schema.py
+++ b/train-simulation/edge/src/edgefarm/schema.py
@@ -11,5 +11,3 @@ unregister_sub_response_codec = fastavro.schema.load_schema(
     "edgefarm/avro_schemas/unregisterSubResponse.avro")
 data_codec = fastavro.schema.load_schema(
     "edgefarm/avro_schemas/dataSchema.avro")
-ads_codec = fastavro.schema.load_schema(
-    "edgefarm/ads-schemas/ads_data.avsc")

--- a/train-simulation/edge/src/main.py
+++ b/train-simulation/edge/src/main.py
@@ -1,16 +1,55 @@
 import io
+import os
 import signal
 import sys
 import asyncio
+import datetime
+import json
 import edgefarm.avro as avro
 from edgefarm.alm_mqtt_module_client import AlmMqttModuleClient
+from edgefarm.ads import AdsProducer, AdsEncoder
+
+#
+# Using ads_client, you can publish a message towards ADS
+#
+ads_client = None
+ads_encoder = None
 
 
 async def temperature_handler(msg):
     """This is the handler function that gets registered for `simulation/temperature`.
-    The data is encoded using `Apache avro` with the schema from the file `edgefarm/avro_schemas/dataSchema.avro`."""
-    message = avro.schema_reader(io.BytesIO(msg.data))
-    print(message)
+    The received data is encoded using `Apache avro` with the schema from the file `edgefarm/avro_schemas/dataSchema.avro`.
+
+    This example unpacks the original message and encodes it into an ADS_DATA avro message (see `edgefarm/ads-schemas/ads_data.avsc`).
+    The payload in ADS_DATA is another AVRO message with a schema for a temperature sensor (see `edgefarm/ads-schemas/temperature_data.avsc`)
+    The whole ADS_DATA message is then sent to ads-node module.
+    """
+    message = avro.schema_decode(io.BytesIO(msg.data))
+
+    org_payload = json.loads(message["payload"])
+    if org_payload["sensorname"] == "temperature":
+        print(org_payload)
+
+        # Generate an ADS payload with "temperature_data" schema
+        ads_payload = {
+            "meta": {"version": b"\x01\x00\x00"},
+            "data": {
+                "time": datetime.datetime.utcfromtimestamp(
+                    int(org_payload["timestamp"])
+                ),
+                "temp": float(org_payload["value"]),
+            },
+        }
+        ads_data_binary = ads_encoder.encode(
+            tags=[{"key": "mon", "value": "true"}],
+            payload_schema="temperature_data",
+            schema_version=b"\x01\x00\x00",
+            data=ads_payload,
+        )
+        # Send data to ads node module
+        await ads_client.publish(ads_data_binary)
+    else:
+        print(f"Received unknown payload: {org_payload}")
 
 
 # You can register multiple handlers for the same MQTT topic.
@@ -19,9 +58,7 @@ async def temperature_handler(msg):
 #   'simulation/temperature': [temp_handler1, temp_handler2],
 #   'simulation/acceleration': [accel_handler]
 # }
-topics = {
-    'simulation/temperature': [temperature_handler]
-}
+topics = {"simulation/temperature": [temperature_handler]}
 
 # This is to store corresponding nats subjects to handler functions for specific MQTT topics.Exception
 # Example for accessing subjects from topics example above:
@@ -31,8 +68,10 @@ subjects = {}
 
 
 async def run(loop):
-    client = AlmMqttModuleClient(loop)
+    global ads_client, ads_encoder
 
+    # Connect to ALM MQTT module and register the MQTT subjects we want to receive
+    client = AlmMqttModuleClient(loop)
     await client.connect()
     try:
         for key in topics:
@@ -47,14 +86,28 @@ async def run(loop):
         sys.stderr.write(f"Error: '{e}'")
         exit(1)
 
+    # Connect to NATS to publish to "ads" subject which is consumed by ADS Node module
+    ads_client = AdsProducer(loop)
+    await ads_client.connect()
+
+    # Instantiate an ADS DATA encoder to produce the ADS avro message
+    # Register the embedded data schemas (here: temperature data)
+    # If you need further schemas, add them to the list of <payload_schemas>
+
+    device_id = os.getenv('IOTEDGE_DEVICEID', 'no-device-id')
+    ads_encoder = AdsEncoder(
+        app="HVAC", module=f"{device_id}.hvac", payload_schemas=["temperature_data"]
+    )
+
     def signal_handler():
         print("Unsubscribing and shutting down...")
         loop.create_task(client.close())
 
-    for sig in ('SIGINT', 'SIGTERM'):
+    for sig in ("SIGINT", "SIGTERM"):
         loop.add_signal_handler(getattr(signal, sig), signal_handler)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run(loop))
     try:

--- a/train-simulation/edge/src/main.py
+++ b/train-simulation/edge/src/main.py
@@ -9,7 +9,7 @@ from edgefarm.alm_mqtt_module_client import AlmMqttModuleClient
 async def temperature_handler(msg):
     """This is the handler function that gets registered for `simulation/temperature`.
     The data is encoded using `Apache avro` with the schema from the file `edgefarm/avro_schemas/dataSchema.avro`."""
-    message = avro.new_reader(io.BytesIO(msg.data))
+    message = avro.schema_reader(io.BytesIO(msg.data))
     print(message)
 
 

--- a/train-simulation/edge/src/main.py
+++ b/train-simulation/edge/src/main.py
@@ -20,8 +20,8 @@ async def temperature_handler(msg):
     """This is the handler function that gets registered for `simulation/temperature`.
     The received data is encoded using `Apache avro` with the schema from the file `edgefarm/avro_schemas/dataSchema.avro`.
 
-    This example unpacks the original message and encodes it into an ADS_DATA avro message (see `edgefarm/ads-schemas/ads_data.avsc`).
-    The payload in ADS_DATA is another AVRO message with a schema for a temperature sensor (see `edgefarm/ads-schemas/temperature_data.avsc`)
+    This example unpacks the original message and encodes it into an ADS_DATA avro message (see `edgefarm/ads_schemas/ads_data.avsc`).
+    The payload in ADS_DATA is another AVRO message with a schema for a temperature sensor (see `edgefarm/ads_schemas/temperature_data.avsc`)
     The whole ADS_DATA message is then sent to ads-node module.
     """
     message = avro.schema_decode(io.BytesIO(msg.data))

--- a/train-simulation/edge/src/tests/nats_ads_subscriber.py
+++ b/train-simulation/edge/src/tests/nats_ads_subscriber.py
@@ -1,0 +1,47 @@
+import os
+from nats.aio.client import Client as Nats
+from io import BytesIO
+import asyncio
+import fastavro
+
+
+async def run(loop):
+    nc = Nats()
+
+    nats_server = os.getenv("NATS_SERVER", "nats:4222")
+    ads_codec = fastavro.schema.load_schema(
+        os.path.join("../edgefarm/ads-schemas", "ads_data.avsc")
+    )
+
+    await nc.connect(servers="nats://" + nats_server, loop=loop)
+    print("nc.connect ok")
+
+    async def message_handler(msg):
+        subject = msg.subject
+        reply = msg.reply
+        ads_data = avro_deserialize(msg.data, ads_codec)
+        data = decode_payload(ads_data["payload"])
+        print(f"Received a message on '{subject} {reply}': {ads_data}\n{data}")
+
+    # Simple publisher and async subscriber via coroutine.
+    await nc.subscribe("ads", cb=message_handler)
+
+
+def decode_payload(payload):
+    codec = fastavro.schema.load_schema(
+        os.path.join("../edgefarm/ads-schemas", payload["schema"])
+    )
+    return avro_deserialize(payload["data"], codec)
+
+
+def avro_deserialize(data, schema):
+    fo = BytesIO(data)
+    m = fastavro.schemaless_reader(fo, schema)
+    return m
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run(loop))
+    loop.run_forever()
+    loop.close()

--- a/train-simulation/edge/src/tests/nats_ads_subscriber.py
+++ b/train-simulation/edge/src/tests/nats_ads_subscriber.py
@@ -10,7 +10,7 @@ async def run(loop):
 
     nats_server = os.getenv("NATS_SERVER", "nats:4222")
     ads_codec = fastavro.schema.load_schema(
-        os.path.join("../edgefarm/ads-schemas", "ads_data.avsc")
+        os.path.join("../edgefarm/ads_schemas", "ads_data.avsc")
     )
 
     await nc.connect(servers="nats://" + nats_server, loop=loop)
@@ -29,7 +29,7 @@ async def run(loop):
 
 def decode_payload(payload):
     codec = fastavro.schema.load_schema(
-        os.path.join("../edgefarm/ads-schemas", payload["schema"])
+        os.path.join("../edgefarm/ads_schemas", payload["schema"])
     )
     return avro_deserialize(payload["data"], codec)
 


### PR DESCRIPTION
- Train-Simulation python program now pushes to ADS Node module
- Train-Simulation uses towards ADS new schemas from ads-schemas submodule. 
- Added nats_ads_subscriber test script to receive messages on "ads" subject